### PR TITLE
fixed installdisk var to work on vagrant reboot for File.exist

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,11 @@ bridgenic = 'eth0'
 #####
 
 
-installdisk = './installdisk.vdi'
+current_dir = File.dirname(File.expand_path(__FILE__))     
+disk_prefix = 'installdisk'
+disk_ext ='.vdi'      
+installdisk =  "%s/%s%s" % [current_dir,disk_prefix,disk_ext]  
+
 
 Vagrant.configure("2") do |config|
 


### PR DESCRIPTION
If vagrant needed to be rebooted or restarted the File.exists? was not valid due to it needed a full path. This fixes the variable to point to your existing VDI and so the custom config block is not run (since it's not needed).