### PR TITLE
Add support for BIN/CUE images, "ISO" images and tar.gz archives

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -64,7 +64,6 @@ function copydist {
 		# Convert BIN/CUE files (e.g. archive.org) to raw EFS
 		for i in /vagrant/irix/$IRIXVERS/$SUB/*.bin
 		do
-			echo "Converting BIN/CUE image \"$i\" to ISO..."
 			i_bn="${i%%.bin}"
 			img="${i_bn}.img"
 			cue="${i_bn}.cue"
@@ -72,6 +71,7 @@ function copydist {
 			# We assume there is only one "ISO" image generated.
 			if [ -f "$cue" ] && [ ! -f "${i_bn}-01.iso" ] ; then
 				# This will create ${i_bn}-01.iso
+				echo "Converting BIN/CUE image \"$i\" to ISO..."
 				bchunk "$i" "$cue" "${i_bn}-"
 			fi
 		done

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -55,10 +55,19 @@ function copydist {
 
 		for i in /vagrant/irix/$IRIXVERS/$SUB/*
 		do
-			echo "Copying files from \"$i\"..."
-			mount -o loop -t efs "$i" /mnt
-			rsync -aq /mnt/ /irix/$SUB
-			umount /mnt
+			case "$( basename "$i" )" in
+			*.tar.gz)	# Tar/Gzip
+				echo "Extracting files from \"$i\"..."
+				mkdir /irix/$SUB
+				tar -C /irix/$SUB -xzpf "$i"
+				;;
+			*)		# EFS image
+				echo "Copying files from \"$i\"..."
+				mount -o loop -t efs "$i" /mnt
+				rsync -aq /mnt/ /irix/$SUB
+				umount /mnt
+				;;
+			esac
 		done
 	done
 	

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -68,8 +68,9 @@ function copydist {
 			i_bn="${i%%.bin}"
 			img="${i_bn}.img"
 			cue="${i_bn}.cue"
-			# Skip .bin missing .cue, or already extracted
-			if [ -f "$cue" ] ; then
+			# Skip .bin missing .cue, or already converted
+			# We assume there is only one "ISO" image generated.
+			if [ -f "$cue" ] && [ ! -f "${i_bn}-01.iso" ] ; then
 				# This will create ${i_bn}-01.iso
 				bchunk "$i" "$cue" "${i_bn}-"
 			fi
@@ -95,7 +96,8 @@ function copydist {
 				# not really an ISO9660 image.  We call it an "ISO"
 				# because bchunk does -- it won't let us call it
 				# anything else.
-				d="$( losetup -f -P -r --show "$i" )"
+				d="$( losetup -f -r --show "$i" )"
+				partprobe ${d}
 				# EFS image is in partition 8
 				extractefs ${d}p8 /irix/$SUB
 				# Unmount loop image

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -18,7 +18,7 @@ invoke-rc.d rsyslog restart
 cp /etc/hosts /etc/hosts.irixboot
 
 echo "Installing packages..."
-apt-get update && apt-get -qq -y install tftpd-hpa isc-dhcp-server rsh-server dnsmasq mksh parted xfsprogs rsync tcpdump
+apt-get update && apt-get -qq -y install tftpd-hpa isc-dhcp-server rsh-server dnsmasq mksh parted xfsprogs rsync tcpdump bchunk
 
 # work around dnsmasq package bug with newer dns-zone-data package
 mv /usr/share/dns/root.ds /usr/share/dns/root.ds.disabled


### PR DESCRIPTION
This adds support for distributions in the following formats:

* Gzipped tar (`.tar.gz`)
* BIN/CUE image format
* "ISO" format (raw SGI disklabel)

Haven't tried booting a SGI machine with this yet (still downloading some of the needed files), but this seems to make the right motions.